### PR TITLE
Ajout de l'email de la personne dans le message

### DIFF
--- a/pytition/petition/views.py
+++ b/pytition/petition/views.py
@@ -113,7 +113,7 @@ def detail(request, petition_id, do_confirmation=False, confirmation_hash=None):
         signature = petition.sign(firstname = firstname, lastname = lastname, email = email, phone = phone,
                                   subscribe = do_subscribe)
         send_confirmation_email(request, signature)
-        successmsg = "Merci d'avoir signé la pétition, vous allez recevoir un e-mail afin de confirmer votre signature.<br>" \
+        successmsg = "Merci d'avoir signé la pétition, un e-mail va vous être envoyé à l'adresse " + email + " afin de confirmer votre signature.<br>" \
                      "Vous devrez cliquer sur le lien à l'intérieur du mail.<br>Si vous ne trouvez pas le mail consultez votre" \
                      "dossier \"spam\" ou \"indésirable\""
 

--- a/pytition/petition/views.py
+++ b/pytition/petition/views.py
@@ -113,9 +113,9 @@ def detail(request, petition_id, do_confirmation=False, confirmation_hash=None):
         signature = petition.sign(firstname = firstname, lastname = lastname, email = email, phone = phone,
                                   subscribe = do_subscribe)
         send_confirmation_email(request, signature)
-        successmsg = "Merci d'avoir signé la pétition, un e-mail va vous être envoyé à l'adresse " + email + " afin de confirmer votre signature.<br>" \
+        successmsg = "Merci d'avoir signé la pétition, un e-mail va vous être envoyé à l'adresse {} afin de confirmer votre signature.<br>" \
                      "Vous devrez cliquer sur le lien à l'intérieur du mail.<br>Si vous ne trouvez pas le mail consultez votre" \
-                     "dossier \"spam\" ou \"indésirable\""
+                     "dossier \"spam\" ou \"indésirable\"".format(email)
 
         if do_subscribe and petition.has_newsletter:
             subscribe_to_newsletter(petition, email)


### PR DESCRIPTION
Ajout de l'email de la personne dans le message prévenant qu'elle va en recevoir un pour valider sa signature.
C'est pour permettre de facilement vérifier si on a entré la bonne adresse sans avoir à ressigner la pétition dans le doute, tant qu'on a pas fermé la page de la pétition en tout cas.

Je suis pas sûr que ce que j'ai fait marche, je dirai que oui mais je suis pas sûr, du coup hésites pas à corriger ^^